### PR TITLE
Limiting the car reverse speed

### DIFF
--- a/android/app/src/main/java/safetyfirst/androidapp/safetyfirstcontroller/MainActivity.java
+++ b/android/app/src/main/java/safetyfirst/androidapp/safetyfirstcontroller/MainActivity.java
@@ -333,11 +333,11 @@ public class MainActivity extends AppCompatActivity implements JoystickView.Joys
         //Here it will publish the yPercent and xPercent as ThrottleSpeed and SteeringAngle to the smartCar
         //If statement to avoid sending messages if the car has detected an obstacle
         if(yPercent <= 0 && driveforwards){
-            mMqttClient.publish(THROTTLE_CONTROL, Integer.toString((int) yPercent), QOS, null);
-            mMqttClient.publish(STEERING_CONTROL, Integer.toString((int) xPercent), QOS, null);
+            mMqttClient.publish(THROTTLE_CONTROL, Double.toString(yPercent / 2), QOS, null);//Dividing the value to prevent reversing at high speeds
+            mMqttClient.publish(STEERING_CONTROL, Double.toString(xPercent), QOS, null);
         }else if(yPercent >= 0 && drivebackwards){
-            mMqttClient.publish(THROTTLE_CONTROL, Integer.toString((int) yPercent), QOS, null);
-            mMqttClient.publish(STEERING_CONTROL, Integer.toString((int) xPercent), QOS, null);
+            mMqttClient.publish(THROTTLE_CONTROL, Double.toString(yPercent), QOS, null);
+            mMqttClient.publish(STEERING_CONTROL, Double.toString(xPercent), QOS, null);
         }
       }
 


### PR DESCRIPTION
This pull request closes #42 

Added some division to simply divide the speed value in 2 when reversing, meaning the car cannot reverse at more than 50% of the normal driving speed. 
Also changed from Integer.toString((int) x) to simply Double.toString(x) to avoid unnecessary casting to int.

### :ballot_box_with_check: Definition of Done checklist
- [x] Meaningful title and valuable description in pull request
- [x] Code change tested manually if not covered by automated tests
- [x] Pull request linked to one or more issues/stories
- [x] Acceptance criteria of the linked stories satisfied
- [x] Code change comprehended by those who approved it
- [x] State of target branch maintained or improved after the code change
